### PR TITLE
allow friskby controlpanel to run in test mode

### DIFF
--- a/run_in_test_mode.py
+++ b/run_in_test_mode.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """
     (c) 2017 FriskbyBergen.
@@ -27,7 +28,7 @@ def start_in_test_mode(host, port):
     cp.app.config['TESTING'] = True
     cp.app.config['FRISKBY_INTERFACE'] = iface
 
-    iface.device_id = 'mydevice'
+    iface.device_id = 'test device'
     iface.sampler_status = 'active'
     iface.sampler_journal = 'Doesn\'t look like anything to me.'
 

--- a/run_in_test_mode.py
+++ b/run_in_test_mode.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+"""
+    (c) 2017 FriskbyBergen.
+
+    Licence
+    =======
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program. If not, see <http://www.gnu.org/licenses/>.
+"""
+import sys
+from friskby_controlpanel import friskby_controlpanel as cp
+from tests.fake_friskby_interface import FakeFriskbyInterface
+
+
+def start_in_test_mode(host, port):
+    iface = FakeFriskbyInterface()
+    cp.app.config['TESTING'] = True
+    cp.app.config['FRISKBY_INTERFACE'] = iface
+
+    iface.device_id = 'mydevice'
+    iface.sampler_status = 'active'
+    iface.sampler_journal = 'Doesn\'t look like anything to me.'
+
+    cp.app.run(
+        debug=True,
+        host=host,
+        port=int(port)
+    )
+
+
+if __name__ == '__main__':
+    port = 5003
+    host = '0.0.0.0'
+    if len(sys.argv) > 1:
+        host = sys.argv[2]
+    if len(sys.argv) > 2:
+        port = sys.argv[3]
+
+    start_in_test_mode(host, port)

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='friskby-controlpanel',
-    version='0.5.0',
+    version='0.5.1',
     description='Friskby device control panel',
     long_description=long_description,
     url='https://github.com/FriskByBergen/python-friskby-controlpanel',


### PR DESCRIPTION
Steps:
1. git clone this repo
2. `./run_in_test_mode.py [host = '0.0.0.0'] [port = 5003]`

fixes #9 