### PR TITLE
completes move to json journactl by actually parsing the json

### DIFF
--- a/friskby_controlpanel/friskby_controlpanel.py
+++ b/friskby_controlpanel/friskby_controlpanel.py
@@ -152,8 +152,8 @@ def status(service_name):
     try:
         service_status = iface.get_service_status(service_name)
         service_journal = iface.get_service_journal(service_name)
-    except ValueError:
-        error = 'No such service: %s.' % service_name
+    except KeyError as e:
+        error = 'No such service: %s (%s).' % (service_name, e)
         print(error)
         sys.stdout.flush()
     else:  # There could be something in the journal at this point.

--- a/friskby_controlpanel/friskby_interface.py
+++ b/friskby_controlpanel/friskby_interface.py
@@ -93,7 +93,7 @@ class FriskbyInterface():
         unit = self._service_to_unit(service)
 
         if service is None:
-            raise ValueError('%s is not a pertinent service.' % service)
+            raise KeyError('%s is not a pertinent service.' % service)
 
         status = self.systemd.get_unit_status(unit)
         try:
@@ -115,7 +115,7 @@ class FriskbyInterface():
         unit = self._service_to_unit(service)
 
         if service is None:
-            raise ValueError('%s is not a pertinent service.' % service)
+            raise KeyError('%s is not a pertinent service.' % service)
 
         output = None
         lines = []
@@ -128,11 +128,13 @@ class FriskbyInterface():
         ]
 
         if limit is None:
-            args + ["--lines", "all"]
+            args = args + ["--lines", "all"]
         else:
-            args + ["--lines", limit]
+            args = args + ["--lines", str(limit)]
 
         try:
+            print("using args,", args)
+            sys.stdout.flush()
             output = subprocess.check_output(args)
         except subprocess.CalledProcessError as e:
             """This means we got a non-zero exit code from journalctl. We can
@@ -143,9 +145,14 @@ class FriskbyInterface():
                                                       e.output))
             sys.stdout.flush()
         else:  # No process error, so let's take a look at the output
-            for line in output:
-                js = json.loads(line)
-                lines.append(js)
+            print("output", output.split("\n"))
+            sys.stdout.flush()
+            for line in output.split("\n"):
+                print("line", line)
+                sys.stdout.flush()
+                if line != "":
+                    js = json.loads(line)
+                    lines.append(js)
 
         lines.reverse()
         return lines

--- a/friskby_controlpanel/friskby_interface.py
+++ b/friskby_controlpanel/friskby_interface.py
@@ -133,8 +133,6 @@ class FriskbyInterface():
             args = args + ["--lines", str(limit)]
 
         try:
-            print("using args,", args)
-            sys.stdout.flush()
             output = subprocess.check_output(args)
         except subprocess.CalledProcessError as e:
             """This means we got a non-zero exit code from journalctl. We can
@@ -145,11 +143,7 @@ class FriskbyInterface():
                                                       e.output))
             sys.stdout.flush()
         else:  # No process error, so let's take a look at the output
-            print("output", output.split("\n"))
-            sys.stdout.flush()
             for line in output.split("\n"):
-                print("line", line)
-                sys.stdout.flush()
                 if line != "":
                     js = json.loads(line)
                     lines.append(js)

--- a/friskby_controlpanel/static/css/style.css
+++ b/friskby_controlpanel/static/css/style.css
@@ -150,12 +150,19 @@ header {
     margin: 0;
     max-height: 500px;
     list-style: none;
-    font-size: 9pt;
+    font-size: 8pt;
     font-family: monospace;
+    overflow-y: scroll;
+}
+
+.log-line td {
+    padding: 0 0 3px 0;
 }
 
 .log-line .timestamp {
     opacity: 0.5;
+    width: 140px;
+    vertical-align: text-top;
 }
 
 .log-line .message {

--- a/friskby_controlpanel/templates/service.html
+++ b/friskby_controlpanel/templates/service.html
@@ -15,16 +15,22 @@
     {% endif %}
 
 
-    <ul class="journal-content">
+    <div class="journal-content">
+        <table>
+        <tbody>
         {% for line in journal %}
-            <li class="log-line">
-            <span class="timestamp">{{line.timestamp_realtime}}</span>
-            <span class="message">{{line.message}}</span>
-            </li>
+            <tr class="log-line">
+                <td class="timestamp">{{line.timestamp_realtime}}</td>
+                <td class="message">{{line.message}}</td>
+            </tr>
         {% else %}
-            <li>Nothing has been logged yet…</li>
+            <tr class="log-line-empty">
+                <td>Nothing has been logged yet…</td>
+            </tr>
         {% endfor %}
-    </ul>
+        </tbody>
+        </table>
+    </div>
 {% endif %}
 
 {% endblock %}


### PR DESCRIPTION
* Raises `KeyError` instead of `ValueError`, since the JSON primary MO for errors are `ValueErrors`.
* Moving away from `<pre>` makes `<table>` (sadly) the best candidate to render the logs.
* Updates css to work with new html.
* Note that the service->unit handling should happen at a higher level, but that refactor will happen in a future branch.