### PR TITLE
Socket bump

### DIFF
--- a/friskby_controlpanel/__init__.py
+++ b/friskby_controlpanel/__init__.py
@@ -1,1 +1,3 @@
 from .friskby_controlpanel import app  # noqa
+
+__version__ = '0.5.2'

--- a/friskby_controlpanel/friskby_controlpanel.py
+++ b/friskby_controlpanel/friskby_controlpanel.py
@@ -91,8 +91,6 @@ def dashboard():
         return redirect(url_for('register'))
 
     sockname = fby_iface.get_socket_iface_address()
-    if not sockname:
-        sockname = 'Unable to obtain socket name.'
     return render_template(
         'dashboard.html',
         has_sampled=fby_iface.get_all_samples_count() > 0,

--- a/friskby_controlpanel/friskby_controlpanel.py
+++ b/friskby_controlpanel/friskby_controlpanel.py
@@ -90,12 +90,16 @@ def dashboard():
     if not device_id:
         return redirect(url_for('register'))
 
+    sockname = fby_iface.get_socket_iface_address()
+    if not sockname:
+        sockname = 'Unable to obtain socket name.'
     return render_template(
         'dashboard.html',
         has_sampled=fby_iface.get_all_samples_count() > 0,
         has_uploaded=fby_iface.get_uploaded_samples_count() > 0,
         most_recent_sample=fby_iface.get_most_recently_sampled(),
-        most_recent_upload=fby_iface.get_most_recently_uploaded())
+        most_recent_upload=fby_iface.get_most_recently_uploaded(),
+        socket_iface_address=sockname)
 
 
 @app.route('/register', methods=['GET', 'POST'])

--- a/friskby_controlpanel/friskby_interface.py
+++ b/friskby_controlpanel/friskby_interface.py
@@ -26,6 +26,7 @@ try:
 except ImportError:
     raise ImportError('Please install python-dbus.')
 
+import socket
 import json
 import subprocess
 import sys
@@ -172,3 +173,14 @@ class FriskbyInterface():
 
     def get_most_recently_sampled(self):
         return self.dao.last_entry()
+
+    @staticmethod
+    def get_socket():
+        try:
+            s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+            s.connect(("friskby.no", 80))
+            sockname = s.getsockname()[0]
+            s.close()
+            return sockname
+        except:
+            return None

--- a/friskby_controlpanel/templates/dashboard.html
+++ b/friskby_controlpanel/templates/dashboard.html
@@ -12,7 +12,11 @@ This device is neither sampling, nor uploading anything to the server.
 </p>
 
 <p>
-  Address: {{ socket_iface_address }}.
+{% if socket_iface_address %}
+This client's address: <code>{{ socket_iface_address }}</code>.
+{% else %}
+Could not obtain this client's address.
+{% endif %}
 </p>
 
 {% endblock %}

--- a/friskby_controlpanel/templates/dashboard.html
+++ b/friskby_controlpanel/templates/dashboard.html
@@ -11,4 +11,8 @@ This device is neither sampling, nor uploading anything to the server.
 {% endif %}
 </p>
 
+<p>
+  Address: {{ socket_iface_address }}.
+</p>
+
 {% endblock %}

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='friskby-controlpanel',
-    version='0.5.1',
+    version='0.5.2',
     description='Friskby device control panel',
     long_description=long_description,
     url='https://github.com/FriskByBergen/python-friskby-controlpanel',

--- a/tests/fake_friskby_interface.py
+++ b/tests/fake_friskby_interface.py
@@ -36,6 +36,7 @@ class FakeFriskbyInterface():
 
         self.sampler_status = None
         self.sampler_journal = []
+        self.socket = None
 
     def download_and_save_config(self, url, filename):
         if self.fails:
@@ -65,3 +66,6 @@ class FakeFriskbyInterface():
 
     def get_most_recently_sampled(self):
         return self.most_recently_sampled
+
+    def get_socket_iface_address(self):
+        return self.socket

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -67,5 +67,12 @@ class DashboardTestCase(unittest.TestCase):
         )
 
 
+    def test_socket_dashboard_no_socket(self):
+        self.iface.device_id = 'mydevice'
+        self.assertIn('Could not obtain', self.app.get('/').data)
+        self.iface.socket = '27.182.81.82'
+        self.assertIn('27.182.81.82', self.app.get('/').data)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Expose the socket name to the website.  That is, show `192.168.0.2` or similar on the dashboard for user to know how to access the website from a personal device (on same network).